### PR TITLE
Fazendo integração do slack via lambda

### DIFF
--- a/Site/.env
+++ b/Site/.env
@@ -17,5 +17,5 @@ APP_HOST='localhost'
 # Configuração do bucket da s3
 BUCKET_NAME='learnfy-database'
 BUCKET_REGION='us-east-1'
-AWS_ACCESS_KEY_ID=''
-AWS_SECRET_ACCESS_KEY=''
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=

--- a/Site/.gitignore
+++ b/Site/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+env/

--- a/Site/src/lambda/lambdaInvokeWithCron.js
+++ b/Site/src/lambda/lambdaInvokeWithCron.js
@@ -1,0 +1,75 @@
+import https from "https";
+import { SecretsManagerClient, GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+import { URL } from "url";
+
+const secret_name = "slack/webhook";
+const region = "us-east-1";
+
+const client = new SecretsManagerClient({ region: region });
+
+async function getSlackWebhookUrl() {
+    console.log("Recuperando URL do webhook do Secrets Manager..."); // Log de início
+    try {
+        const response = await client.send(
+            new GetSecretValueCommand({
+                SecretId: secret_name,
+                VersionStage: "AWSCURRENT", // VersionStage defaults to AWSCURRENT if unspecified
+            })
+        );
+        const secret = response.SecretString;
+        const secretObject = JSON.parse(secret);
+        console.log("URL do Webhook recuperada:", secretObject.SLACK_WEBHOOK_URL); // Log para mostrar a URL
+        return secretObject.SLACK_WEBHOOK_URL;
+    } catch (error) {
+        console.error("Erro ao recuperar o segredo:", error); // Log de erro
+        throw error;
+    }
+};
+
+export const handler = async (event) => {
+    console.log("Evento recebido:", event); // Log para mostrar o evento recebido
+
+    const slackUrlRaw = await getSlackWebhookUrl();
+    const slackUrl = new URL(slackUrlRaw);
+
+    const status = event.status || "DESCONHECIDO";
+    const horario = event.executadoEm || new Date().toISOString();
+    const container = event.container || "NÃO INFORMADO";
+
+    const mensagem = {
+        text: `Atualização diária detectada!*\n\n*Status:* ${status}\n*Horário:* ${horario}`
+    };
+
+    console.log("Mensagem a ser enviada para o Slack:", JSON.stringify(mensagem)); // Log da mensagem a ser enviada
+
+    const options = {
+        hostname: slackUrl.hostname,
+        path: slackUrl.pathname, // Verifique se você está usando pathname e não path
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+    };
+
+    await new Promise((resolve, reject) => {
+        const req = https.request(options, (res) => {
+            res.on("data", () => { });
+            res.on("end", resolve);
+        });
+
+        req.on("error", (err) => {
+            console.error("Erro ao enviar para o Slack:", err); // Log de erro
+            reject(err);
+        });
+
+        req.write(JSON.stringify(mensagem));
+        req.end();
+    });
+
+    console.log("Notificação enviada ao Slack com sucesso!"); // Log de sucesso
+
+    return {
+        statusCode: 200,
+        body: JSON.stringify("Notificação enviada ao Slack com sucesso!"),
+    };
+};

--- a/Site/src/routes/aws.js
+++ b/Site/src/routes/aws.js
@@ -30,7 +30,7 @@ router.post("/posts", upload.single("file"), async (req, res) => {
 
     const command = new PutObjectCommand({
         Bucket: process.env.BUCKET_NAME,
-        Key: req.file.originalname,
+        Key: `planilhas/${req.file.originalname}`,
         Body: req.file.buffer,
         ContentType: req.file.mimetype,
     });


### PR DESCRIPTION
Integração de envio de notificações via Slack. 

Para isso foi feito uma nova lambda que envia uma requisição no endPoint do Slack.

Adição de novo arquivo na pasta de Lambdas (lambdaInvokeWithCron). O gatilho de ativação dessa lambda é manual, sendo necessário um payload como o a seguir: 

{
  "status": "SUCESSO",
  "executadoEm": "2025-04-20T20:30:00Z",
  "container": "container-java-importador"
}

# Para invocação da Lambda é necessário ter o AWS CLI instalado, onde os dados de credenciais serão do nosso usuário de serverless deployer

aws lambda invoke \
  --function-name lambda-notifica-slack \
  --cli-binary-format raw-in-base64-out \
  --payload '{"status": "SUCESSO", "executadoEm": "2025-04-20T23:59:00Z", "container": "container-java"}' \
  /dev/null


